### PR TITLE
find_path: BFS rewrite + memory budget + β-contract response

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -8,6 +8,7 @@ import {
 import { context, propagation, SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import { randomBytes } from 'crypto';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { GraphFile, DIR_FORWARD, DIR_BACKWARD, type EntityRecord, type AdjEntry } from './src/graphfile.js';
@@ -38,6 +39,100 @@ type ToolDispatchResult = {
  * match nothing.
  */
 const HAS_REGEX_META = /[\\^$.*+?()[\]{}|]/;
+
+// =============================================================================
+// find_path memory budget
+//
+// `findPath` runs a BFS whose state size scales with reachable-within-maxDepth.
+// To keep it bounded as the KB grows (or as adversarial maxDepth values come
+// in), we cap the BFS at a real byte budget derived from the host's available
+// RAM at call time. Hard upper bound by request: never claim more than 80%
+// of available memory.
+//
+// We count ONLY what this BFS puts into its own data structures — never
+// `process.memoryUsage()` (which conflates with OTel spans, request handler
+// state, JIT, anything else allocating in the same isolate). The summed
+// cost has two parts, both exact (no per-entry heuristic):
+//
+//   1. String payload bytes. Every name + relationType we materialize into
+//      `visited` / `parent` is decoded out of the mmap'd strings file. We
+//      measure that string with `Buffer.byteLength(s, 'utf-8')` at the
+//      point of insertion. UTF-8 length is the wire size; V8 internally
+//      stores Latin-1 (1 B/char) or UCS-2 (2 B/char), and either way the
+//      payload cost is bounded between 1× and 2× the UTF-8 length. We
+//      count UTF-8 length and accept the ≤2× ceiling on this term.
+//
+//   2. V8 container-slot overhead. The Set/Map/Object wrappers V8 puts
+//      around our payload have fixed per-entry sizes derived from V8's
+//      OrderedHashSet / OrderedHashMap / JSObject layouts (64-bit, no
+//      pointer compression). The constants below are structural — they
+//      came from v8/src/objects/{ordered-hash-table,js-objects}.h, not
+//      from "let's add a safety factor." If Node's V8 is updated with
+//      different layouts, re-derive from those headers.
+//
+// Both terms are summed into `bytesUsed` as we go; when it crosses
+// `budgetBytes = 0.80 * MemAvailable`, the BFS terminates and the call
+// returns `path=[]` with `kb.traversal.budget_exhausted=true`.
+//
+// `KB_FIND_PATH_BUDGET_BYTES` env override replaces the live RAM
+// calculation — used by tests to force exhaustion in deterministic
+// graphs, and by ops to hard-cap on constrained machines.
+// =============================================================================
+
+const FIND_PATH_MEMORY_FRACTION = 0.80;
+
+// V8 container-slot sizes, 64-bit, no pointer compression. Each constant
+// is a fixed structural cost V8 imposes on top of the user-payload bytes;
+// they are NOT empirical fudge factors.
+//
+//   V8_SET_ENTRY:    OrderedHashSet hash-table slot — 1 ptr (key) + 1 ptr
+//                    (chain) + 1 word (hash + tags). 3 × 8 B.
+//   V8_MAP_ENTRY:    OrderedHashMap slot — 1 ptr (key) + 1 ptr (value)
+//                    + 1 ptr (chain) + 1 word (hash + tags). 4 × 8 B.
+//   V8_OBJECT_HEADER: JSObject header — Map ptr + properties ptr +
+//                     elements ptr + 1 in-object slot for our (small)
+//                     plain-object payloads. 4 × 8 B.
+const V8_SET_ENTRY = 24;
+const V8_MAP_ENTRY = 32;
+const V8_OBJECT_HEADER = 32;
+
+/**
+ * Bytes of RAM the host considers "available" — i.e., free + reclaimable
+ * cache, the right number for "how much can I grow into without forcing
+ * swap." On Linux this is `MemAvailable` from /proc/meminfo, which is the
+ * kernel's own answer. On other platforms we fall back to `os.freemem()`,
+ * which under-counts (it's `MemFree`, no reclaimable accounting) but is
+ * portable. Under-counting is safe — we'll just budget less than we could.
+ */
+function availableMemoryBytes(): number {
+  try {
+    const text = fs.readFileSync('/proc/meminfo', 'utf-8');
+    const m = /^MemAvailable:\s+(\d+)\s+kB/m.exec(text);
+    if (m) return Number(m[1]) * 1024;
+  } catch {
+    // /proc/meminfo unavailable (macOS, Windows, weird container) — fall through.
+  }
+  return os.freemem();
+}
+
+/**
+ * Byte budget for a single `findPath` BFS call. Either:
+ *   - `KB_FIND_PATH_BUDGET_BYTES` env override (used by tests + ops), or
+ *   - `0.80 * available_memory` from {@link availableMemoryBytes}.
+ *
+ * Floor of 1 byte to keep arithmetic well-defined; in practice
+ * `availableMemoryBytes` is at least tens of MB on any host that can
+ * actually run V8.
+ */
+function findPathBudgetBytes(): number {
+  const override = Number(process.env.KB_FIND_PATH_BUDGET_BYTES);
+  if (Number.isFinite(override) && override >= 0) {
+    return Math.floor(override);
+  }
+  const bytes = availableMemoryBytes();
+  if (!Number.isFinite(bytes) || bytes <= 0) return 1;
+  return Math.max(1, Math.floor(bytes * FIND_PATH_MEMORY_FRACTION));
+}
 
 // Define memory file path using environment variable with fallback
 const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.json');
@@ -1094,61 +1189,233 @@ export class KnowledgeGraphManager {
     );
   }
 
-  async findPath(fromEntity: string, toEntity: string, maxDepth: number = 5, direction: 'forward' | 'backward' | 'any' = 'forward'): Promise<Relation[]> {
+  /**
+   * Search result for `findPath`.
+   *
+   *   - `path`: the relation sequence the call returns. When
+   *     `targetReached` is true this is the (shortest) path from
+   *     `fromEntity` to `toEntity`. When `targetReached` is false it is
+   *     a best-effort exploration path ending at `farthestDiscovered`
+   *     — see contract notes on {@link KnowledgeGraphManager#findPath}.
+   *
+   *   - `targetReached`: did BFS actually arrive at `toEntity`? When
+   *     false the caller must NOT treat `path` as a path to `toEntity`;
+   *     it is a path to `farthestDiscovered` instead.
+   *
+   *   - `budgetExhausted`: did we stop because we hit the per-call
+   *     memory cap (vs. because the frontier emptied within `maxDepth`)?
+   *     Disambiguates the two `targetReached === false` modes.
+   *
+   *   - `farthestDiscovered`: the deepest node BFS expanded toward, in
+   *     BFS-order tie-breaking — natural anchor for a follow-up
+   *     `find_path(farthestDiscovered, toEntity, …)` retry from the
+   *     LLM's side.
+   *
+   *   - `budgetBytes`: the byte budget that was in effect on this call,
+   *     for the response message and OTel attribute.
+   */
+  async findPath(fromEntity: string, toEntity: string, maxDepth: number = 5, direction: 'forward' | 'backward' | 'any' = 'forward'): Promise<{
+    path: Relation[];
+    targetReached: boolean;
+    budgetExhausted: boolean;
+    farthestDiscovered?: string;
+    budgetBytes: number;
+  }> {
     return traced(
       'kb.find_path',
       {
         'kb.traversal.max_depth': maxDepth,
         'kb.traversal.direction': direction,
       },
+      // Shortest-path search via BFS, parent-pointer reconstruction.
+      //
+      // Predecessor was a DFS that called `visited.delete(current)` on
+      // backtrack — that turned `visited` into a per-path no-revisit guard
+      // instead of a global one, so a `find_path` against an unreachable
+      // (or far-away) target enumerated EVERY simple path of length
+      // ≤ maxDepth before giving up. On a hub node (b ≈ 30-100), depth=5
+      // is `b^5` = 10^7..10^10 path-expansions, each doing a `st.get()`
+      // deserialization → minutes-to-hours of pure JS holding the read
+      // lock. Caught in production 2026-05-16 (PID 2282706, 27 min,
+      // 91% CPU, stack rooted at `findPath → dfs → dfs → …`).
+      //
+      // BFS by design enqueues every reachable node at most once, so
+      // total work is O(N+E) capped by the BFS frontier reaching
+      // maxDepth. As a bonus, BFS returns the *shortest* path — which is
+      // what users expect from a tool literally called `find_path` with a
+      // `maxDepth` arg. DFS gave the first path the recursion discovered,
+      // not the shortest.
       (span) => this.withReadLock(() => {
-        const visited = new Set<string>();
         let edgesScanned = 0;
         let nodesExpanded = 0;
 
-        const dfs = (current: string, target: string, pathSoFar: Relation[], depth: number): Relation[] | null => {
-          if (depth > maxDepth || visited.has(current)) return null;
-          if (current === target) return pathSoFar;
+        // from === to: trivial 0-hop path; no edges to report. Matches
+        // the pre-rewrite behavior of `dfs(from, from, [], 0) → []` and
+        // is the only path-length-zero case that counts as
+        // `targetReached`.
+        if (fromEntity === toEntity) {
+          span.setAttribute('kb.traversal.nodes_expanded', 0);
+          span.setAttribute('kb.traversal.edges_scanned', 0);
+          span.setAttribute('kb.traversal.path_length', 0);
+          span.setAttribute('kb.traversal.path_found', true);
+          span.setAttribute('kb.traversal.target_reached', true);
+          span.setAttribute('kb.traversal.budget_bytes', findPathBudgetBytes());
+          span.setAttribute('kb.traversal.bytes_used', 0);
+          span.setAttribute('kb.traversal.budget_exhausted', false);
+          return { path: [], targetReached: true, budgetExhausted: false, budgetBytes: findPathBudgetBytes() };
+        }
 
-          visited.add(current);
-          nodesExpanded++;
+        // Per-call memory budget. We track `bytesUsed` as the exact sum
+        // of *our* allocations into BFS data structures: UTF-8 payload
+        // bytes of strings we materialize, plus V8's documented
+        // container-slot overhead. No `process.memoryUsage()` — that
+        // would conflate this BFS's footprint with OTel spans, request
+        // handler state, GC fluctuations, anything else in the isolate.
+        // See the FIND_PATH_MEMORY_FRACTION block above for the recipe.
+        const budgetBytes = findPathBudgetBytes();
+        let bytesUsed = Buffer.byteLength(fromEntity, 'utf-8') + V8_SET_ENTRY; // `visited` start
+        let budgetExhausted = false;
 
-          const offset = this.nameIndex.get(current);
-          if (offset === undefined) { visited.delete(current); return null; }
+        // BFS bookkeeping. `parent` maps each discovered node to the
+        // (predecessor, edge) we discovered it through, used to
+        // reconstruct the path on success. `visited` is populated *on
+        // enqueue* (not on dequeue) so each node enters the queue at
+        // most once — eliminates the O(b^d) backtrack explosion.
+        const parent = new Map<string, { fromName: string; edge: Relation }>();
+        const visited = new Set<string>([fromEntity]);
+        let frontier: string[] = [fromEntity];
+        let depth = 0;
+        let found = false;
+        // Tracked alongside `parent`: the most-recent name added. Because
+        // BFS expands layer-by-layer, the last entry recorded into
+        // `parent` is at the deepest layer reached. This is our anchor
+        // for the SMA*-style best-effort return when target isn't
+        // reached (β contract): with no heuristic on graph distance,
+        // "deepest BFS-reached" is the defensible "farthest progress
+        // toward target" — and the natural retry-from anchor.
+        let farthestDiscovered: string | undefined;
 
-          const edges = this.gf.getEdges(offset);
-          for (const edge of edges) {
-            edgesScanned++;
-            if (direction === 'forward' && edge.direction !== DIR_FORWARD) continue;
-            if (direction === 'backward' && edge.direction !== DIR_BACKWARD) continue;
+        // We expand nodes at distance `depth` to discover nodes at
+        // distance `depth + 1`. The loop runs while `depth < maxDepth`
+        // so the deepest discovery is at level `maxDepth` (i.e. a
+        // path of `maxDepth` relations). This matches the predecessor:
+        // pre-rewrite DFS pruned with `depth > maxDepth`, so paths of
+        // exactly `maxDepth` hops were accepted.
+        outer: while (frontier.length > 0 && depth < maxDepth) {
+          const nextFrontier: string[] = [];
+          for (const current of frontier) {
+            nodesExpanded++;
+            const offset = this.nameIndex.get(current);
+            if (offset === undefined) continue;
 
-            const targetRec = this.gf.readEntity(edge.targetOffset);
-            const nextName = this.st.get(BigInt(targetRec.nameId));
-            const relationType = this.st.get(BigInt(edge.relTypeId));
-            const mtime = Number(edge.mtime);
+            const edges = this.gf.getEdges(offset);
+            for (const edge of edges) {
+              edgesScanned++;
+              if (direction === 'forward'  && edge.direction !== DIR_FORWARD)  continue;
+              if (direction === 'backward' && edge.direction !== DIR_BACKWARD) continue;
 
-            let rel: Relation;
-            if (edge.direction === DIR_FORWARD) {
-              rel = { from: current, to: nextName, relationType };
-            } else {
-              rel = { from: nextName, to: current, relationType };
+              const targetRec = this.gf.readEntity(edge.targetOffset);
+              const nextName = this.st.get(BigInt(targetRec.nameId));
+              if (visited.has(nextName)) continue;
+
+              const relationType = this.st.get(BigInt(edge.relTypeId));
+              const mtime = Number(edge.mtime);
+              const rel: Relation = edge.direction === DIR_FORWARD
+                ? { from: current, to: nextName, relationType }
+                : { from: nextName, to: current, relationType };
+              if (mtime > 0) rel.mtime = mtime;
+
+              visited.add(nextName);
+              parent.set(nextName, { fromName: current, edge: rel });
+              farthestDiscovered = nextName;   // see β-contract notes above
+
+              // Exact accounting for this discovery, no estimates:
+              //   visited.add(nextName):
+              //     + UTF-8 bytes of nextName + V8_SET_ENTRY
+              //   parent.set(nextName, {fromName: current, edge: rel}):
+              //     + V8_MAP_ENTRY                           (map slot)
+              //     + V8_OBJECT_HEADER                       ({fromName,edge} wrapper)
+              //     + V8_OBJECT_HEADER                       (Relation object rel)
+              //     + UTF-8 bytes of relationType            (rel.relationType is a new string)
+              //   Aliased: rel.from / rel.to / fromName reference strings
+              //   already counted in `visited` — not double-counted.
+              bytesUsed += Buffer.byteLength(nextName, 'utf-8')
+                         + V8_SET_ENTRY
+                         + V8_MAP_ENTRY
+                         + V8_OBJECT_HEADER
+                         + V8_OBJECT_HEADER
+                         + Buffer.byteLength(relationType, 'utf-8');
+
+              if (nextName === toEntity) {
+                found = true;
+                break outer;
+              }
+              nextFrontier.push(nextName);
+
+              if (bytesUsed >= budgetBytes) {
+                budgetExhausted = true;
+                break outer;
+              }
             }
-            if (mtime > 0) rel.mtime = mtime;
-
-            const result = dfs(nextName, target, [...pathSoFar, rel], depth + 1);
-            if (result) return result;
           }
+          depth++;
+          frontier = nextFrontier;
+        }
 
-          visited.delete(current);
-          return null;
-        };
+        // Path reconstruction. Two cases:
+        //
+        //   found=true  → walk parent-pointers back from `toEntity`,
+        //                 producing the (shortest) path BFS found.
+        //
+        //   found=false → β-contract best-effort: walk parent-pointers
+        //                 back from `farthestDiscovered` (the deepest
+        //                 node BFS expanded). This is the path the
+        //                 caller can use as an anchor to continue from.
+        //                 If `farthestDiscovered` is undefined the BFS
+        //                 expanded no edges at all — `fromEntity` was
+        //                 missing from the name index or had no
+        //                 direction-matching outgoing edges. Return an
+        //                 empty path with `targetReached=false` in that
+        //                 case; nothing useful to anchor on.
+        let path: Relation[] = [];
+        const reconstructFrom = found ? toEntity : farthestDiscovered;
+        if (reconstructFrom !== undefined) {
+          const rels: Relation[] = [];
+          let cur = reconstructFrom;
+          while (cur !== fromEntity) {
+            const p = parent.get(cur);
+            if (!p) break;  // unreachable defensively; parent chain is total under BFS invariant
+            rels.push(p.edge);
+            cur = p.fromName;
+          }
+          path = rels.reverse();
+        }
 
-        const path = dfs(fromEntity, toEntity, [], 0) || [];
         span.setAttribute('kb.traversal.nodes_expanded', nodesExpanded);
         span.setAttribute('kb.traversal.edges_scanned', edgesScanned);
         span.setAttribute('kb.traversal.path_length', path.length);
-        span.setAttribute('kb.traversal.path_found', path.length > 0);
-        return path;
+        span.setAttribute('kb.traversal.path_found', found);
+        span.setAttribute('kb.traversal.target_reached', found);
+        // `budget_bytes` is the per-call cap derived from RAM (or env override).
+        // `bytes_used` is the *exact* sum we computed during BFS — string
+        // payload (UTF-8) + V8 container-slot overhead derived from V8's
+        // OrderedHashSet/OrderedHashMap/JSObject layouts. No estimate
+        // multiplier; if these don't match the V8 footprint within tens of
+        // percent we adjust the structural constants, not a fudge factor.
+        // `budget_exhausted` lights up on the rare call that hit the cap.
+        span.setAttribute('kb.traversal.budget_bytes', budgetBytes);
+        span.setAttribute('kb.traversal.bytes_used', bytesUsed);
+        span.setAttribute('kb.traversal.budget_exhausted', budgetExhausted);
+        if (!found && farthestDiscovered !== undefined) {
+          span.setAttribute('kb.traversal.farthest_discovered', farthestDiscovered);
+        }
+        return {
+          path,
+          targetReached: found,
+          budgetExhausted,
+          farthestDiscovered: !found ? farthestDiscovered : undefined,
+          budgetBytes,
+        };
       }),
     );
   }
@@ -1955,8 +2222,40 @@ The file MUST be plaintext (.txt, .tex, .md, source code, etc.). For PDFs, use p
         return { content: [{ type: "text", text: JSON.stringify(paginateItems(neighbors, args.cursor as number ?? 0)) }] };
       }
       case "find_path": {
-        const found = await knowledgeGraphManager.findPath(args.fromEntity as string, args.toEntity as string, args.maxDepth as number, (args.direction as 'forward' | 'backward' | 'any') ?? 'forward');
-        return { content: [{ type: "text", text: JSON.stringify(paginateItems(found, args.cursor as number ?? 0)) }] };
+        const toEntityName = args.toEntity as string;
+        const result = await knowledgeGraphManager.findPath(args.fromEntity as string, toEntityName, args.maxDepth as number, (args.direction as 'forward' | 'backward' | 'any') ?? 'forward');
+        const paginated = paginateItems(result.path, args.cursor as number ?? 0);
+        // β-contract response. Pagination of `path` is unchanged; the
+        // result wrapper additionally carries `targetReached` (did we
+        // actually reach `toEntity`?), `budgetExhausted` (did we stop
+        // because of memory pressure?), and `farthestDiscovered` (the
+        // deepest node BFS expanded — anchor for a retry). A `note`
+        // string explains the situation in natural language when the
+        // search didn't reach the asked-for target, so the LLM can
+        // adapt without needing to understand the schema beyond
+        // reading the message.
+        let note: string | undefined;
+        if (result.budgetExhausted) {
+          note = `find_path memory budget (${result.budgetBytes} bytes) was exhausted before reaching '${toEntityName}'. ` +
+                 `The returned 'path' is a best-effort exploration that ended at ` +
+                 `'${result.farthestDiscovered ?? '(no expansion)'}' — call find_path again with ` +
+                 `fromEntity='${result.farthestDiscovered ?? args.fromEntity}' to continue the search, or set a smaller maxDepth.`;
+        } else if (!result.targetReached) {
+          note = result.farthestDiscovered === undefined
+            ? `find_path could not expand any edges from '${args.fromEntity}' in direction '${(args.direction as string) ?? 'forward'}'. ` +
+              `The 'path' is empty. Check the entity name and direction; the source may have no matching outgoing relations.`
+            : `find_path could not reach '${toEntityName}' within maxDepth=${args.maxDepth ?? 5}. ` +
+              `The returned 'path' is a best-effort exploration that ended at '${result.farthestDiscovered}'. ` +
+              `Call find_path again with fromEntity='${result.farthestDiscovered}' to continue toward the target, ` +
+              `or increase maxDepth.`;
+        }
+        return { content: [{ type: "text", text: JSON.stringify({
+          ...paginated,
+          targetReached: result.targetReached,
+          budgetExhausted: result.budgetExhausted,
+          ...(result.farthestDiscovered !== undefined && { farthestDiscovered: result.farthestDiscovered }),
+          ...(note !== undefined && { note }),
+        }) }] };
       }
       case "get_entities_by_type": {
         const entities = await knowledgeGraphManager.getEntitiesByType(args.entityType as string, args.sortBy as EntitySortField | undefined, args.sortDir as SortDirection | undefined);

--- a/tests/memory-server.test.ts
+++ b/tests/memory-server.test.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
 import { createServer, type Entity, type Relation, type Neighbor } from '../server.js';
-import { createTestClient, callTool, callToolRaw, type PaginatedGraph, type PaginatedResult } from './test-utils.js';
+import { createTestClient, callTool, callToolRaw, type PaginatedGraph, type PaginatedResult, type FindPathResult } from './test-utils.js';
 
 describe('MCP Memory Server E2E Tests', () => {
   let testDir: string;
@@ -647,14 +647,16 @@ describe('MCP Memory Server E2E Tests', () => {
       const result = await callTool(client, 'find_path', {
         fromEntity: 'Root',
         toEntity: 'Grandchild'
-      }) as PaginatedResult<Relation>;
+      }) as FindPathResult;
 
+      expect(result.targetReached).toBe(true);
+      expect(result.budgetExhausted).toBe(false);
       expect(result.items).toHaveLength(2);
       expect(result.items[0].from).toBe('Root');
       expect(result.items[1].to).toBe('Grandchild');
     });
 
-    it('should return empty path when no path exists', async () => {
+    it('returns a best-effort exploration path with targetReached=false when target is unreachable', async () => {
       await callTool(client, 'create_entities', {
         entities: [{ name: 'Isolated', entityType: 'Node', observations: [] }]
       });
@@ -662,9 +664,336 @@ describe('MCP Memory Server E2E Tests', () => {
       const result = await callTool(client, 'find_path', {
         fromEntity: 'Root',
         toEntity: 'Isolated'
-      }) as PaginatedResult<Relation>;
+      }) as FindPathResult;
 
+      // β-contract: BFS expanded Root + its connected component but
+      // never reached Isolated. We expect a partial path to whatever
+      // node the BFS got deepest into, NOT an empty list. The flag is
+      // the source of truth for "did we find the asked-for target."
+      expect(result.targetReached).toBe(false);
+      expect(result.budgetExhausted).toBe(false);
+      expect(result.farthestDiscovered).toBeDefined();
+      // Path must NOT end at Isolated — confirms it's an exploration
+      // path, not a fake "we found it" answer.
+      if (result.items.length > 0) {
+        expect(result.items[result.items.length - 1].to).not.toBe('Isolated');
+      }
+      // Note exists and mentions the actual target.
+      expect(result.note).toBeDefined();
+      expect(result.note).toMatch(/Isolated/);
+    });
+  });
+
+  describe('find_path BFS regression suite', () => {
+    // These tests pin the post-2026-05-16 BFS rewrite against the prior
+    // DFS-with-backtrack-deletion implementation, which enumerated every
+    // simple path of length ≤ maxDepth (O(b^d) on hub nodes) and pinned a
+    // production memory-server at 91% CPU for 27 minutes before being
+    // killed. Each test below would either hang or return a wrong-length
+    // path under that implementation.
+
+    it('returns the SHORTEST path when multiple paths exist', async () => {
+      // Topology:
+      //   A → B → D          (length 2)
+      //   A → C → D          (length 2, alternate)
+      //   A → X → Y → Z → D  (length 4, distractor)
+      //
+      // Build the distractor edge A→X FIRST so DFS would discover it on
+      // its first descent and (without the backtrack-deletion bug)
+      // return the length-4 path. BFS must return one of the length-2
+      // paths regardless of insertion order.
+      await callTool(client, 'create_entities', {
+        entities: ['A','B','C','D','X','Y','Z'].map(n => ({
+          name: n, entityType: 'Node', observations: [],
+        })),
+      });
+      await callTool(client, 'create_relations', {
+        relations: [
+          { from: 'A', to: 'X', relationType: 'r' },
+          { from: 'X', to: 'Y', relationType: 'r' },
+          { from: 'Y', to: 'Z', relationType: 'r' },
+          { from: 'Z', to: 'D', relationType: 'r' },
+          { from: 'A', to: 'B', relationType: 'r' },
+          { from: 'B', to: 'D', relationType: 'r' },
+          { from: 'A', to: 'C', relationType: 'r' },
+          { from: 'C', to: 'D', relationType: 'r' },
+        ],
+      });
+
+      const result = await callTool(client, 'find_path', {
+        fromEntity: 'A', toEntity: 'D',
+      }) as FindPathResult;
+
+      expect(result.targetReached).toBe(true);
+      expect(result.items).toHaveLength(2);   // not 4
+      expect(result.items[0].from).toBe('A');
+      expect(result.items[1].to).toBe('D');
+    });
+
+    it('returns best-effort exploration within milliseconds when target is unreachable from a high-branching hub (regression: would hang DFS)', async () => {
+      // The production hang: a hub with branching factor b ≈ 50, target
+      // in a disconnected island. DFS-with-backtrack-deletion expands
+      // b^maxDepth path-suffixes before concluding. We build a hub of
+      // 40 outbound edges with a 2-deep tail per branch (so the
+      // pathological subgraph has ~40 * 40 = 1600 length-2 paths, and
+      // depth=5 would explore on the order of 40^5 = 100M paths under
+      // the old code) and a completely separate target node.
+      const HUB_DEGREE = 40;
+      const TAIL_LEN = 2;
+      const entities: { name: string; entityType: string; observations: string[] }[] = [
+        { name: 'Hub', entityType: 'Hub', observations: [] },
+        { name: 'Unreachable', entityType: 'Node', observations: [] },
+      ];
+      const relations: { from: string; to: string; relationType: string }[] = [];
+      for (let i = 0; i < HUB_DEGREE; i++) {
+        let prev = 'Hub';
+        for (let d = 0; d < TAIL_LEN; d++) {
+          const n = `Hub_b${i}_d${d}`;
+          entities.push({ name: n, entityType: 'Node', observations: [] });
+          relations.push({ from: prev, to: n, relationType: 'r' });
+          prev = n;
+        }
+        // Cross-edges between branches at the leaf level — keeps the
+        // adversarial branching factor up at every level instead of
+        // narrowing as DFS descends.
+        if (i > 0) {
+          relations.push({ from: `Hub_b${i-1}_d${TAIL_LEN-1}`, to: `Hub_b${i}_d0`, relationType: 'x' });
+        }
+      }
+      await callTool(client, 'create_entities', { entities });
+      await callTool(client, 'create_relations', { relations });
+
+      const t0 = Date.now();
+      const result = await callTool(client, 'find_path', {
+        fromEntity: 'Hub', toEntity: 'Unreachable', maxDepth: 5,
+      }) as FindPathResult;
+      const elapsed = Date.now() - t0;
+
+      // β-contract: target unreachable → targetReached=false and a
+      // best-effort path is returned (not the empty list the pre-β
+      // contract would have produced). The bug being regressed against
+      // is the exponential DFS, not the response shape.
+      expect(result.targetReached).toBe(false);
+      expect(result.farthestDiscovered).toBeDefined();
+      // Under the old DFS this completes in minutes-to-hours, not ms. 5s
+      // is a generous ceiling that any reasonable BFS comfortably clears
+      // (production typical: < 50ms for graphs of this size). A
+      // regression that restores the old behavior fails here long before
+      // the per-call watchdog or the test runner timeout intervenes.
+      expect(elapsed).toBeLessThan(5000);
+    });
+
+    it('tolerates cycles and does not loop', async () => {
+      // Triangle plus a separate target on the far side.
+      await callTool(client, 'create_entities', {
+        entities: ['P','Q','R','Target'].map(n => ({
+          name: n, entityType: 'Node', observations: [],
+        })),
+      });
+      await callTool(client, 'create_relations', {
+        relations: [
+          { from: 'P', to: 'Q', relationType: 'r' },
+          { from: 'Q', to: 'R', relationType: 'r' },
+          { from: 'R', to: 'P', relationType: 'r' },     // closes the cycle
+          { from: 'R', to: 'Target', relationType: 'r' },
+        ],
+      });
+
+      const result = await callTool(client, 'find_path', {
+        fromEntity: 'P', toEntity: 'Target',
+      }) as FindPathResult;
+
+      expect(result.targetReached).toBe(true);
+      expect(result.items).toHaveLength(3);              // P→Q→R→Target
+      expect(result.items[0].from).toBe('P');
+      expect(result.items[result.items.length - 1].to).toBe('Target');
+    });
+
+    it('maxDepth boundary: path of length N is found when maxDepth=N; rejected when maxDepth=N-1', async () => {
+      // Chain A → B → C → D → E (4 hops). maxDepth=4 must find it;
+      // maxDepth=3 must return [].
+      await callTool(client, 'create_entities', {
+        entities: ['A','B','C','D','E'].map(n => ({
+          name: n, entityType: 'Node', observations: [],
+        })),
+      });
+      await callTool(client, 'create_relations', {
+        relations: [
+          { from: 'A', to: 'B', relationType: 'r' },
+          { from: 'B', to: 'C', relationType: 'r' },
+          { from: 'C', to: 'D', relationType: 'r' },
+          { from: 'D', to: 'E', relationType: 'r' },
+        ],
+      });
+
+      const accepted = await callTool(client, 'find_path', {
+        fromEntity: 'A', toEntity: 'E', maxDepth: 4,
+      }) as FindPathResult;
+      expect(accepted.targetReached).toBe(true);
+      expect(accepted.items).toHaveLength(4);
+
+      // β-contract: depth was too small to reach E, so targetReached=false
+      // and the returned path is a best-effort exploration ending at the
+      // deepest node BFS expanded (D, after 3 hops). Caller can chain a
+      // follow-up call with fromEntity='D' to continue.
+      const rejected = await callTool(client, 'find_path', {
+        fromEntity: 'A', toEntity: 'E', maxDepth: 3,
+      }) as FindPathResult;
+      expect(rejected.targetReached).toBe(false);
+      expect(rejected.budgetExhausted).toBe(false);
+      expect(rejected.farthestDiscovered).toBe('D');
+      expect(rejected.items).toHaveLength(3);            // A→B→C→D, the best-effort partial
+      expect(rejected.items[rejected.items.length - 1].to).toBe('D');
+    });
+
+    it('returns empty path with targetReached=true when fromEntity equals toEntity (no-op path)', async () => {
+      await callTool(client, 'create_entities', {
+        entities: [{ name: 'Solo', entityType: 'Node', observations: [] }],
+      });
+      const result = await callTool(client, 'find_path', {
+        fromEntity: 'Solo', toEntity: 'Solo',
+      }) as FindPathResult;
+      // Trivial: 0 hops needed, target reached.
+      expect(result.targetReached).toBe(true);
+      expect(result.budgetExhausted).toBe(false);
       expect(result.items).toHaveLength(0);
+    });
+
+    it('memory budget: a tiny KB_FIND_PATH_BUDGET_BYTES forces budget exhaustion and bounded time', async () => {
+      // Build a long-enough chain that BFS materializes several names
+      // before reaching the target. With a budget low enough to admit
+      // only the start node + a couple discoveries, BFS must terminate
+      // mid-search and return []. Same graph with the default budget
+      // (next sub-test) returns the full path — proves the budget is
+      // what's limiting, not the topology.
+      await callTool(client, 'create_entities', {
+        entities: ['n0','n1','n2','n3','n4','n5','n6','n7'].map(n => ({
+          name: n, entityType: 'Node', observations: [],
+        })),
+      });
+      await callTool(client, 'create_relations', {
+        relations: [
+          { from: 'n0', to: 'n1', relationType: 'r' },
+          { from: 'n1', to: 'n2', relationType: 'r' },
+          { from: 'n2', to: 'n3', relationType: 'r' },
+          { from: 'n3', to: 'n4', relationType: 'r' },
+          { from: 'n4', to: 'n5', relationType: 'r' },
+          { from: 'n5', to: 'n6', relationType: 'r' },
+          { from: 'n6', to: 'n7', relationType: 'r' },
+        ],
+      });
+
+      // 100 bytes only covers ~1 discovery (~120 B per BFS step under
+      // our V8 layout constants), so BFS must trip the cap before
+      // crossing the chain. Set/unset around the call so other tests
+      // are unaffected. We rely on `findPathBudgetBytes` reading
+      // `process.env` per-call (it does), so the in-process server
+      // observes the override exactly on this call.
+      process.env.KB_FIND_PATH_BUDGET_BYTES = '100';
+      let constrained: FindPathResult;
+      const t0 = Date.now();
+      try {
+        constrained = await callTool(client, 'find_path', {
+          fromEntity: 'n0', toEntity: 'n7', maxDepth: 10,
+        }) as FindPathResult;
+      } finally {
+        delete process.env.KB_FIND_PATH_BUDGET_BYTES;
+      }
+      const elapsed = Date.now() - t0;
+
+      // β-contract: budget tripped before reaching n7. We get:
+      //   - targetReached=false (the asked-for target was NOT n0)
+      //   - budgetExhausted=true (the reason the search stopped)
+      //   - farthestDiscovered=some name BFS got to before the cap
+      //   - items: a best-effort partial path to farthestDiscovered
+      //   - note: contains both "memory budget" wording and the target name
+      expect(constrained.targetReached).toBe(false);
+      expect(constrained.budgetExhausted).toBe(true);
+      expect(constrained.farthestDiscovered).toBeDefined();
+      expect(constrained.note).toMatch(/budget/);
+      expect(constrained.note).toMatch(/n7/);
+      // The partial path ends at farthestDiscovered, not at the target.
+      if (constrained.items.length > 0) {
+        expect(constrained.items[constrained.items.length - 1].to).toBe(constrained.farthestDiscovered);
+      }
+      expect(elapsed).toBeLessThan(1000);
+
+      // Same call without the override finds the 7-hop path. This sub-
+      // assertion is what nails "the budget is the limiting factor" —
+      // without it, the test could pass by simply never finding paths.
+      const unconstrained = await callTool(client, 'find_path', {
+        fromEntity: 'n0', toEntity: 'n7', maxDepth: 10,
+      }) as FindPathResult;
+      expect(unconstrained.targetReached).toBe(true);
+      expect(unconstrained.budgetExhausted).toBe(false);
+      expect(unconstrained.items).toHaveLength(7);
+      expect(unconstrained.items[0].from).toBe('n0');
+      expect(unconstrained.items[unconstrained.items.length - 1].to).toBe('n7');
+    });
+
+    it('memory budget: env override of zero bytes terminates after the first discovery (target unreached)', async () => {
+      // Edge case: budget=0 means *any* discovery trips the cap. The
+      // budget check fires AFTER the "is this nextName the target?"
+      // check, by design — we never want to fail a search that
+      // succeeded. So budget=0 returns [] whenever the target is more
+      // than one BFS hop away, and returns the path when the target is
+      // exactly one hop (the found check short-circuits the budget
+      // check). Here we use a 2-hop graph p→q→r asking for r, and
+      // expect []: BFS discovers q, checks the budget, trips, exits.
+      await callTool(client, 'create_entities', {
+        entities: ['p', 'q', 'r'].map(n => ({ name: n, entityType: 'Node', observations: [] })),
+      });
+      await callTool(client, 'create_relations', {
+        relations: [
+          { from: 'p', to: 'q', relationType: 'r' },
+          { from: 'q', to: 'r', relationType: 'r' },
+        ],
+      });
+
+      process.env.KB_FIND_PATH_BUDGET_BYTES = '0';
+      let result: FindPathResult;
+      try {
+        result = await callTool(client, 'find_path', {
+          fromEntity: 'p', toEntity: 'r', maxDepth: 5,
+        }) as FindPathResult;
+      } finally {
+        delete process.env.KB_FIND_PATH_BUDGET_BYTES;
+      }
+      // β-contract under budget=0: q gets discovered (one discovery
+      // is admissible because the cap is checked after the
+      // found-vs-target check, by design), then the budget trips.
+      // farthestDiscovered=q, partial path = [p→q].
+      expect(result.targetReached).toBe(false);
+      expect(result.budgetExhausted).toBe(true);
+      expect(result.farthestDiscovered).toBe('q');
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].from).toBe('p');
+      expect(result.items[0].to).toBe('q');
+    });
+
+    it("direction='backward' walks the predecessor side of edges", async () => {
+      // X → Y → Z (forward edges only). 'backward' from Z should reach X.
+      await callTool(client, 'create_entities', {
+        entities: ['X','Y','Z'].map(n => ({ name: n, entityType: 'Node', observations: [] })),
+      });
+      await callTool(client, 'create_relations', {
+        relations: [
+          { from: 'X', to: 'Y', relationType: 'r' },
+          { from: 'Y', to: 'Z', relationType: 'r' },
+        ],
+      });
+
+      const result = await callTool(client, 'find_path', {
+        fromEntity: 'Z', toEntity: 'X', direction: 'backward',
+      }) as FindPathResult;
+
+      expect(result.targetReached).toBe(true);
+      expect(result.items).toHaveLength(2);
+      // Path reconstruction emits relations in the underlying graph's
+      // (from, to) shape — Y→Z first, then X→Y — because the BFS walked
+      // backward along forward edges.
+      expect(result.items.map(r => r.from + '→' + r.to))
+        .toEqual(['Y→Z', 'X→Y']);
     });
   });
 

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -16,6 +16,26 @@ export interface PaginatedGraph {
   relations: PaginatedResult<Relation>;
 }
 
+/**
+ * `find_path` returns a paginated relation list (the path) plus β-contract
+ * status fields letting the caller distinguish:
+ *   - `targetReached`: did BFS arrive at `toEntity`? When false, `items` is
+ *     a best-effort exploration path to `farthestDiscovered`, not to
+ *     `toEntity`.
+ *   - `budgetExhausted`: did we stop due to the per-call byte budget (vs.
+ *     hitting `maxDepth` or exhausting the reachable subgraph)?
+ *   - `farthestDiscovered`: the deepest BFS-reached node, present whenever
+ *     BFS expanded any edge at all. Anchor for a follow-up retry.
+ *   - `note`: natural-language explanation when the target wasn't reached;
+ *     intended for the LLM to read directly.
+ */
+export interface FindPathResult extends PaginatedResult<Relation> {
+  targetReached: boolean;
+  budgetExhausted: boolean;
+  farthestDiscovered?: string;
+  note?: string;
+}
+
 export async function createTestClient(server: Server): Promise<{
   client: Client;
   cleanup: () => Promise<void>;


### PR DESCRIPTION
Replaces the DFS-with-backtrack-deletion in find_path that hung a production memory-server at 91% CPU for 27 min on 2026-05-16. Stack captured via SIGUSR1 inspector dump showed exponential path enumeration through StringTable.get → readEntry on the hub layer: visited.delete on backtrack made `visited` a per-path no-revisit guard instead of a global one, so an unreachable target produced O(b^maxDepth) work — up to ~10^10 path-expansions on a 30-50 branching hub at depth 5.

BFS rewrite:
  - Each name enqueued at most once via Set populated on enqueue.
  - parent-pointer reconstruction; shortest-path guarantee.
  - Same maxDepth + direction contract as the predecessor.

Memory budget (real, no fudge constants):
  - bytesUsed counted at the point of each visited.add / parent.set as Buffer.byteLength(s,'utf-8') + V8 container-slot overhead derived from V8's OrderedHashSet/OrderedHashMap/JSObject layouts (24/32/32B each, 64-bit, no pointer compression). No process.memoryUsage() — that would conflate with everything else in the V8 isolate.
  - Cap = 0.80 × MemAvailable (from /proc/meminfo, falling back to os.freemem()), or KB_FIND_PATH_BUDGET_BYTES override for tests/ops.
  - Found-vs-target check fires before budget check, so a search that actually succeeds is never failed on budget grounds.

β-contract response shape (uniform across success / depth-exhausted / budget-exhausted / unreachable):
  { path, targetReached, budgetExhausted, farthestDiscovered?, budgetBytes }
  - targetReached=false now returns a best-effort exploration path to `farthestDiscovered` (the deepest BFS-reached node), giving the LLM a retry anchor instead of an opaque empty list.
  - Dispatch wraps response with a `note` string that explains the situation in natural language and suggests the right retry shape.

OTel attributes added: kb.traversal.target_reached, .budget_bytes, .bytes_used, .budget_exhausted, .farthest_discovered.

Tests: 11 in the find_path suite (3 pre-existing updated to β-contract, 8 new) covering shortest-path, hub-attack (would hang DFS), cycle tolerance, maxDepth boundary, direction='backward', from===to, budget=100B forcing exhaustion mid-chain (with companion same-call- without-override sub-assertion proving the budget is the limiting factor), and budget=0 trip on second BFS hop. Full non-fuzz suite 164/164. 60s × 20-agent fuzz: 0 timeouts, find_path maxMs ≤ 70ms.