### PR TITLE
tracing: derive SERVICE_VERSION from package.json (was hardcoded '0.0…

### DIFF
--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -33,9 +33,55 @@ import {
   type Span,
   type Tracer,
 } from '@opentelemetry/api';
+import { existsSync, readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 
 const SERVICE_NAME = process.env.OTEL_SERVICE_NAME ?? 'memory-server';
-const SERVICE_VERSION = '0.0.20';
+
+/**
+ * Resolve our own package version at module-load by walking up from this
+ * file to the nearest `package.json`. Works in both dev (running from
+ * `src/`) and the published shape (running from `dist/src/`), because in
+ * both cases the closest ancestor `package.json` is ours (subsequent
+ * ancestors would belong to a consumer project, which is also fine —
+ * if our `package.json` is somehow missing we'd accidentally report the
+ * consumer's version; covered by the existsSync at the closest level).
+ *
+ * Previously this was a hardcoded `'0.0.20'` literal that nobody
+ * remembered to bump, so every span and metric for v0.0.21 .. 0.0.24
+ * carried a four-version-old `service.version` attribute. Tooling that
+ * filters or rolls up by service version was silently misled.
+ */
+function resolveServiceVersion(): string {
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    const { root } = (function parseRoot(): { root: string } {
+      // Mirrors the pattern in src/memoryfile.ts:findNative — avoid
+      // pulling in `path.parse` at the top of the module just for this.
+      const m = /^([A-Z]:\\|\/)/.exec(dir);
+      return { root: m ? m[1] : '/' };
+    })();
+    while (dir !== root) {
+      const candidate = join(dir, 'package.json');
+      if (existsSync(candidate)) {
+        const pkg = JSON.parse(readFileSync(candidate, 'utf-8')) as { name?: string; version?: string };
+        if (typeof pkg.version === 'string') return pkg.version;
+      }
+      dir = dirname(dir);
+    }
+  } catch {
+    // Best-effort — see fallback below. Tracing must never throw at init.
+  }
+  return 'unknown';
+}
+
+/**
+ * Version of *this* package, used as `service.version` on every span and
+ * metric. Read once at module load from our `package.json` so OTel data
+ * doesn't lie about which build is emitting it.
+ */
+export const SERVICE_VERSION = resolveServiceVersion();
 
 /**
  * Stderr-only diag logger. Avoids contaminating the JSON-RPC stdout channel.

--- a/tests/tracing.test.ts
+++ b/tests/tracing.test.ts
@@ -119,3 +119,24 @@ describe('tracing — stdio purity', () => {
     }
   }, 15000);
 });
+
+/**
+ * Regression: the OTel `service.version` resource attribute used to be a
+ * hardcoded `'0.0.20'` literal in `src/tracing.ts`. Four version bumps
+ * (0.0.21 → 0.0.24) all shipped with the stale value, silently misleading
+ * any tooling that filtered or rolled up traces/metrics by version. The
+ * fix reads the package version dynamically from `package.json`. This
+ * test pins that behavior: if anyone ever puts a literal back in
+ * `tracing.ts`, this fails the moment the next `npm version bump` lands.
+ */
+describe('tracing — service.version reflects package.json', () => {
+  it("SERVICE_VERSION equals the package's declared version", async () => {
+    const { SERVICE_VERSION } = await import('../src/tracing.js');
+    const pkgPath = path.resolve(__dirname, '..', 'package.json');
+    const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf-8')) as { version: string };
+    expect(SERVICE_VERSION).toBe(pkg.version);
+    // And specifically not the historical wrong value, so a fresh-eyes
+    // reviewer can grep this exact string when debugging.
+    expect(SERVICE_VERSION).not.toBe('0.0.20');
+  });
+});


### PR DESCRIPTION
….20')

The OTel `service.version` resource attribute was a hardcoded literal that nobody bumped after 0.0.20. Four releases (0.0.21 .. 0.0.24) shipped with the stale value, so every trace and metric tagged this process as 0.0.20 — silently misleading any tooling that filtered or rolled up by service version.

Discovered while diagnosing a separate hang on 2026-05-16: while probing Tempo I noticed `service.version=0.0.20` on a fresh trace from 0.0.24, and pulled this thread.

Replaces the literal with `resolveServiceVersion()`, which walks up from this file's location to the nearest `package.json` and reads its `version` field. Works for both the dev shape (running from `src/`) and the published shape (running from `dist/src/`); fallback `'unknown'` keeps tracing init from throwing if `package.json` is somehow missing.

Test: `tests/tracing.test.ts` adds a sub-suite that imports the runtime `SERVICE_VERSION` and asserts it equals `package.json`'s `version`, and is explicitly not `'0.0.20'`. The latter is the canary — if anyone ever puts a literal back, this fails the moment the next version bump lands.